### PR TITLE
feat: turns on KubeVirt expand disk size feature

### DIFF
--- a/roles/ks-virt/templates/kubevirt-feature-gates.yaml.j2
+++ b/roles/ks-virt/templates/kubevirt-feature-gates.yaml.j2
@@ -7,4 +7,4 @@ metadata:
     kubevirt.io: ""
 data:
   debug.useEmulation: "{{ virtualization.useEmulation | default(false) | lower }}"
-  feature-gates: "DataVolume,Macvtap,LiveMigration,Snapshot,HotplugVolumes"
+  feature-gates: "DataVolume,Macvtap,LiveMigration,Snapshot,HotplugVolumes,ExpandDisks"


### PR DESCRIPTION
Turns on KubeVirt expand disk size feature, to solve the problem of when a vm's system disk size is bigger than the image's disk size, the available system disk size is limited to image's size.