### PR TITLE
Mount temporary hostpath directory for ks-apiserver

### DIFF
--- a/roles/ks-core/ks-core/files/ks-core/templates/ks-apiserver.yml
+++ b/roles/ks-core/ks-core/files/ks-core/templates/ks-apiserver.yml
@@ -48,6 +48,8 @@ spec:
         - mountPath: /etc/localtime
           name: host-time
           readOnly: true
+        - mountPath: /tmp
+          name: local-tmp
         {{- if .Values.apiserver.extraVolumeMounts }}
           {{- toYaml .Values.apiserver.extraVolumeMounts | nindent 8 }}
         {{- end }}
@@ -101,6 +103,10 @@ spec:
           path: /etc/localtime
           type: ""
         name: host-time
+      - hostPath:
+          path: /tmp
+          type: ""
+        name: local-tmp
       {{- if .Values.apiserver.extraVolumes }}
         {{ toYaml .Values.apiserver.extraVolumes | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
### The content of this PR is as follows:

* When using the `/kapis/file.ecpaas.io/v1/upload` API, the uploaded files will be stored in the `ks-apiserver` Pod.
* However, the uploader Job will read the local /tmp path to move the file to the PVC. In order to prevent the Job from not finding the file on the host path, the /tmp host path is mounted for ks-apiserver.